### PR TITLE
Allow user to adjust docSpec.

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,7 +12,11 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "mime-types": "2.1.22",
+=======
+        "mime-types": "~2.1.18",
+>>>>>>> Allow user to adjust docSpec.
         "negotiator": "0.6.1"
       }
     },
@@ -21,10 +25,17 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.4.1",
         "uri-js": "4.2.2"
+=======
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "ansi-regex": {
@@ -37,7 +48,11 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "color-convert": "1.9.3"
+=======
+        "color-convert": "^1.9.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "append-field": {
@@ -55,8 +70,13 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "delegates": "1.0.0",
         "readable-stream": "2.3.6"
+=======
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "array-flatten": {
@@ -69,7 +89,11 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safer-buffer": "2.1.2"
+=======
+        "safer-buffer": "~2.1.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "assert-plus": {
@@ -102,7 +126,11 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "tweetnacl": "0.14.5"
+=======
+        "tweetnacl": "^0.14.3"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "bindings": {
@@ -119,6 +147,7 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "content-type": "1.0.4",
         "debug": "2.6.9",
         "depd": "1.1.2",
@@ -128,6 +157,17 @@
         "qs": "6.5.2",
         "raw-body": "2.3.3",
         "type-is": "1.6.16"
+=======
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "brace-expansion": {
@@ -135,7 +175,11 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "balanced-match": "1.0.0",
+=======
+        "balanced-match": "^1.0.0",
+>>>>>>> Allow user to adjust docSpec.
         "concat-map": "0.0.1"
       }
     },
@@ -155,7 +199,11 @@
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
         "dicer": "0.2.5",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "readable-stream": "1.1.14"
+=======
+        "readable-stream": "1.1.x"
+>>>>>>> Allow user to adjust docSpec.
       },
       "dependencies": {
         "isarray": {
@@ -168,10 +216,17 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "0.0.1",
             "string_decoder": "0.10.31"
+=======
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+>>>>>>> Allow user to adjust docSpec.
           }
         },
         "string_decoder": {
@@ -196,9 +251,15 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
         "supports-color": "5.5.0"
+=======
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "charenc": {
@@ -234,7 +295,11 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "delayed-stream": "1.0.0"
+=======
+        "delayed-stream": "~1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "commander": {
@@ -252,10 +317,17 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "buffer-from": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
+=======
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "console-control-strings": {
@@ -307,7 +379,11 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "assert-plus": "1.0.0"
+=======
+        "assert-plus": "^1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "debug": {
@@ -353,7 +429,11 @@
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "readable-stream": "1.1.14",
+=======
+        "readable-stream": "1.1.x",
+>>>>>>> Allow user to adjust docSpec.
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -367,10 +447,17 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "0.0.1",
             "string_decoder": "0.10.31"
+=======
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+>>>>>>> Allow user to adjust docSpec.
           }
         },
         "string_decoder": {
@@ -385,8 +472,13 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "jsbn": "0.1.1",
         "safer-buffer": "2.1.2"
+=======
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "ecdsa-sig-formatter": {
@@ -394,7 +486,11 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safe-buffer": "5.1.2"
+=======
+        "safe-buffer": "^5.0.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "ee-first": {
@@ -432,6 +528,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
@@ -454,14 +551,45 @@
         "proxy-addr": "2.0.4",
         "qs": "6.5.2",
         "range-parser": "1.2.0",
+=======
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+>>>>>>> Allow user to adjust docSpec.
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "statuses": "1.4.0",
         "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
+=======
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "extend": {
@@ -495,12 +623,21 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "statuses": "1.4.0",
         "unpipe": "1.0.0"
+=======
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "find-process": {
@@ -508,9 +645,15 @@
       "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.1.tgz",
       "integrity": "sha512-RkYWDeukxEoDKUyocqMGKAYuwhSwq77zL99gCqhX9czWon3otdlzihJ0MSZ6YWNKHyvS/MN2YR4+RGYOuIEANg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "chalk": "2.4.2",
         "commander": "2.20.0",
         "debug": "2.6.9"
+=======
+        "chalk": "^2.0.1",
+        "commander": "^2.11.0",
+        "debug": "^2.6.8"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "forever-agent": {
@@ -523,9 +666,15 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "asynckit": "0.4.0",
         "combined-stream": "1.0.7",
         "mime-types": "2.1.22"
+=======
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "forwarded": {
@@ -543,9 +692,15 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "graceful-fs": "4.1.15",
         "jsonfile": "4.0.0",
         "universalify": "0.1.2"
+=======
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "fs-minipass": {
@@ -553,7 +708,11 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "minipass": "2.3.5"
+=======
+        "minipass": "^2.2.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "fs.realpath": {
@@ -566,6 +725,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
         "has-unicode": "2.0.1",
@@ -574,6 +734,16 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "wide-align": "1.1.3"
+=======
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "getpass": {
@@ -581,7 +751,11 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "assert-plus": "1.0.0"
+=======
+        "assert-plus": "^1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "glob": {
@@ -589,12 +763,21 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
+=======
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "graceful-fs": {
@@ -612,8 +795,13 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "ajv": "6.10.0",
         "har-schema": "2.0.0"
+=======
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "has-flag": {
@@ -631,10 +819,17 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": "1.4.0"
+=======
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "http-signature": {
@@ -642,9 +837,15 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.16.1"
+=======
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "iconv-lite": {
@@ -652,7 +853,11 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safer-buffer": "2.1.2"
+=======
+        "safer-buffer": ">= 2.1.2 < 3"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "ignore-walk": {
@@ -660,7 +865,11 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "minimatch": "3.0.4"
+=======
+        "minimatch": "^3.0.4"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "inflight": {
@@ -668,8 +877,13 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "once": "1.4.0",
         "wrappy": "1.0.2"
+=======
+        "once": "^1.3.0",
+        "wrappy": "1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "inherits": {
@@ -692,7 +906,11 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "number-is-nan": "1.0.1"
+=======
+        "number-is-nan": "^1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "is-typedarray": {
@@ -735,7 +953,11 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "graceful-fs": "4.1.15"
+=======
+        "graceful-fs": "^4.1.6"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "jsonwebtoken": {
@@ -743,6 +965,7 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "jws": "3.2.2",
         "lodash.includes": "4.3.0",
         "lodash.isboolean": "3.0.3",
@@ -753,6 +976,18 @@
         "lodash.once": "4.1.1",
         "ms": "2.1.1",
         "semver": "5.7.0"
+=======
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+>>>>>>> Allow user to adjust docSpec.
       },
       "dependencies": {
         "ms": {
@@ -780,7 +1015,11 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safe-buffer": "5.1.2"
+=======
+        "safe-buffer": "^5.0.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "jws": {
@@ -788,12 +1027,27 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "jwa": "1.4.1",
         "safe-buffer": "5.1.2"
+=======
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "libxmljs-mt": {
+      "version": "git+https://github.com/alexdee2007/libxmljs.git#625f5e072756ec4a36d6e81e84b70aca4ee16296",
+      "from": "git+https://github.com/alexdee2007/libxmljs.git",
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "~2.10.0",
+        "node-pre-gyp": "^0.9.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "libxslt": {
       "version": "git+https://github.com/alexdee2007/node-libxslt.git#24ba6f97593444ae340c94eb120c623001813ae5",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
       "requires": {
         "bindings": "1.5.0",
         "libxmljs-mt": "git+https://github.com/alexdee2007/libxmljs.git#625f5e072756ec4a36d6e81e84b70aca4ee16296",
@@ -808,6 +1062,13 @@
             "node-pre-gyp": "0.9.1"
           }
         }
+=======
+      "from": "git+https://github.com/alexdee2007/node-libxslt.git",
+      "requires": {
+        "bindings": "^1.3.0",
+        "libxmljs-mt": "git+https://github.com/alexdee2007/libxmljs.git#625f5e072756ec4a36d6e81e84b70aca4ee16296",
+        "nan": "~2.10.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "lodash.includes": {
@@ -850,7 +1111,11 @@
       "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
       "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "nopt": "2.1.2"
+=======
+        "nopt": "~2.1.1"
+>>>>>>> Allow user to adjust docSpec.
       },
       "dependencies": {
         "nopt": {
@@ -858,7 +1123,11 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
           "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
           "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
             "abbrev": "1.1.1"
+=======
+            "abbrev": "1"
+>>>>>>> Allow user to adjust docSpec.
           }
         }
       }
@@ -893,7 +1162,11 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "mime-db": "1.38.0"
+=======
+        "mime-db": "~1.38.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "minimatch": {
@@ -901,7 +1174,11 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "brace-expansion": "1.1.11"
+=======
+        "brace-expansion": "^1.1.7"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "minimist": {
@@ -914,8 +1191,13 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safe-buffer": "5.1.2",
         "yallist": "3.0.3"
+=======
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "minizlib": {
@@ -923,7 +1205,11 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "minipass": "2.3.5"
+=======
+        "minipass": "^2.2.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "mkdirp": {
@@ -944,6 +1230,7 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
       "integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "append-field": "1.0.0",
         "busboy": "0.2.14",
         "concat-stream": "1.6.2",
@@ -952,6 +1239,16 @@
         "on-finished": "2.3.0",
         "type-is": "1.6.16",
         "xtend": "4.0.1"
+=======
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "nan": {
@@ -960,6 +1257,7 @@
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "needle": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
       "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
@@ -967,6 +1265,30 @@
         "debug": "2.6.9",
         "iconv-lite": "0.4.23",
         "sax": "1.2.4"
+=======
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "negotiator": {
@@ -979,6 +1301,7 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
       "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "detect-libc": "1.0.3",
         "mkdirp": "0.5.1",
         "needle": "2.2.4",
@@ -989,6 +1312,18 @@
         "rimraf": "2.6.3",
         "semver": "5.7.0",
         "tar": "4.4.8"
+=======
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "nodemailer": {
@@ -1001,8 +1336,13 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "abbrev": "1.1.1",
         "osenv": "0.1.5"
+=======
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "npm-bundled": {
@@ -1015,8 +1355,13 @@
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
       "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "ignore-walk": "3.0.1",
         "npm-bundled": "1.0.6"
+=======
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "npmlog": {
@@ -1024,10 +1369,17 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "are-we-there-yet": "1.1.5",
         "console-control-strings": "1.1.0",
         "gauge": "2.7.4",
         "set-blocking": "2.0.0"
+=======
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "number-is-nan": {
@@ -1058,7 +1410,11 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "wrappy": "1.0.2"
+=======
+        "wrappy": "1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "os-homedir": {
@@ -1076,8 +1432,13 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
+=======
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "parseurl": {
@@ -1110,7 +1471,11 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "forwarded": "0.1.2",
+=======
+        "forwarded": "~0.1.2",
+>>>>>>> Allow user to adjust docSpec.
         "ipaddr.js": "1.8.0"
       }
     },
@@ -1150,10 +1515,17 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
+=======
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+>>>>>>> Allow user to adjust docSpec.
       },
       "dependencies": {
         "minimist": {
@@ -1168,6 +1540,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
@@ -1175,6 +1548,15 @@
         "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
+=======
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "request": {
@@ -1182,6 +1564,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "aws-sign2": "0.7.0",
         "aws4": "1.8.0",
         "caseless": "0.12.0",
@@ -1202,6 +1585,28 @@
         "tough-cookie": "2.4.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.3.2"
+=======
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "rimraf": {
@@ -1209,7 +1614,11 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "glob": "7.1.3"
+=======
+        "glob": "^7.1.3"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "safe-buffer": {
@@ -1238,6 +1647,7 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "depd": "1.1.2",
         "destroy": "1.0.4",
         "encodeurl": "1.0.2",
@@ -1250,6 +1660,20 @@
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.4.0"
+=======
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "serve-static": {
@@ -1257,9 +1681,15 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
+=======
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+>>>>>>> Allow user to adjust docSpec.
         "send": "0.16.2"
       }
     },
@@ -1278,8 +1708,13 @@
       "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
       "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "charenc": "0.0.2",
         "crypt": "0.0.2"
+=======
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "signal-exit": {
@@ -1292,9 +1727,15 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.6.tgz",
       "integrity": "sha512-EqBXxHdKiwvNMRCgml86VTL5TK1i0IKiumnfxykX0gh6H6jaKijAXvE9O1N7+omfNSawR2fOmIyJZcfe8HYWpw==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "nan": "2.10.0",
         "node-pre-gyp": "0.11.0",
         "request": "2.88.0"
+=======
+        "nan": "~2.10.0",
+        "node-pre-gyp": "^0.11.0",
+        "request": "^2.87.0"
+>>>>>>> Allow user to adjust docSpec.
       },
       "dependencies": {
         "node-pre-gyp": {
@@ -1302,6 +1743,7 @@
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
           "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
           "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
             "needle": "2.2.4",
@@ -1312,6 +1754,18 @@
             "rimraf": "2.6.3",
             "semver": "5.7.0",
             "tar": "4.4.8"
+=======
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+>>>>>>> Allow user to adjust docSpec.
           }
         }
       }
@@ -1321,6 +1775,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "asn1": "0.2.4",
         "assert-plus": "1.0.0",
         "bcrypt-pbkdf": "1.0.2",
@@ -1330,6 +1785,17 @@
         "jsbn": "0.1.1",
         "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
+=======
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "statuses": {
@@ -1347,9 +1813,15 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+=======
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "string_decoder": {
@@ -1357,7 +1829,11 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safe-buffer": "5.1.2"
+=======
+        "safe-buffer": "~5.1.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "strip-ansi": {
@@ -1365,7 +1841,11 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "ansi-regex": "2.1.1"
+=======
+        "ansi-regex": "^2.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "strip-json-comments": {
@@ -1378,7 +1858,11 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "has-flag": "3.0.0"
+=======
+        "has-flag": "^3.0.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "tar": {
@@ -1386,6 +1870,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
       "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "chownr": "1.1.1",
         "fs-minipass": "1.2.5",
         "minipass": "2.3.5",
@@ -1393,6 +1878,15 @@
         "mkdirp": "0.5.1",
         "safe-buffer": "5.1.2",
         "yallist": "3.0.3"
+=======
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "tough-cookie": {
@@ -1400,8 +1894,13 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "psl": "1.1.31",
         "punycode": "1.4.1"
+=======
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+>>>>>>> Allow user to adjust docSpec.
       },
       "dependencies": {
         "punycode": {
@@ -1416,7 +1915,11 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "safe-buffer": "5.1.2"
+=======
+        "safe-buffer": "^5.0.1"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "tweetnacl": {
@@ -1430,7 +1933,11 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "mime-types": "2.1.22"
+=======
+        "mime-types": "~2.1.18"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "typedarray": {
@@ -1453,7 +1960,11 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "punycode": "2.1.1"
+=======
+        "punycode": "^2.1.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "util-deprecate": {
@@ -1481,9 +1992,15 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
+=======
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "wide-align": {
@@ -1491,7 +2008,11 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
+<<<<<<< ea6bba1282694428239db430bc4695b1d6b863df
         "string-width": "1.0.2"
+=======
+        "string-width": "^1.0.2 || 2"
+>>>>>>> Allow user to adjust docSpec.
       }
     },
     "wrappy": {

--- a/website/views/config-editing-override.ejs
+++ b/website/views/config-editing-override.ejs
@@ -36,7 +36,7 @@
 		};
 		Screenful.Editor.allowSourceCode=false;
 		Screenful.Editor.toolbarLinks=[
-			{image: "../../../furniture/cancel.png", caption: "Stop using your own entry editor...", href: "../../../<%=dictID%>/config/editing/"}
+			{image: "../../../furniture/cancel.png", caption: "Disable entry editor customizations...", href: "../../../<%=dictID%>/config/editing/"}
 		];
 		</script>
 		<link type="text/css" rel="stylesheet" href="../../../furniture/ui.css" />

--- a/website/views/config-editing.ejs
+++ b/website/views/config-editing.ejs
@@ -32,7 +32,7 @@
 			Editing.change=Screenful.Editor.changed;
 			if(!entry.content.xonomyMode) entry.content.xonomyMode="nerd";
 			Editing.render(div, entry.content);
-			if(entry.content._js) { //the user is switching back from own entry editor
+			if(entry.content._js) { //the user is disabling any entry editor customizations
 				delete entry.content._js;
 				delete entry.content._css;
 				window.setTimeout(Screenful.Editor.changed, 100);
@@ -52,7 +52,7 @@
 			return JSON.parse(str);
 		};
 		Screenful.Editor.toolbarLinks=[
-			{image: "../../../furniture/cog.png", caption: "Use your own entry editor...", href: "../../../<%=dictID%>/config/editing-override/"}
+			{image: "../../../furniture/cog.png", caption: "Customize entry editor...", href: "../../../<%=dictID%>/config/editing-override/"}
 		];
 		</script>
 		<link type="text/css" rel="stylesheet" href="../../../furniture/ui.css" />

--- a/website/views/entryeditor.ejs
+++ b/website/views/entryeditor.ejs
@@ -28,9 +28,15 @@
 			<%-editing._css%>
 		</style>
 		<%if(editing._js){%>
-			<script type="text/javascript">var ownEditor=<%-editing._js%>;</script>
+			<script type="text/javascript">
+				var customizeEditor=<%-editing._js%>;
+				var usingOwnEditor=customizeEditor.editor && customizeEditor.harvester;
+			</script>
 		<%} else {%>
-			<script type="text/javascript">var ownEditor=null;</script>
+			<script type="text/javascript">
+				var customizeEditor=null;
+				var usingOwnEditor=false;
+			</script>
 		<%}%>
 		<script type="text/javascript">
 		Screenful.Editor.createUrl="../../../<%=dictID%>/entrycreate.json";
@@ -108,18 +114,21 @@
 					}
 				}
 			}
-			if(!ownEditor){
+
+			if(!usingOwnEditor){
+				if(customizeEditor.adjustDocSpec)
+					customizeEditor.adjustDocSpec(docSpec);
 				Xonomy.render((entry ? entry.content : newXml), div, docSpec);
 				if(!Xonomy.keyNav) Xonomy.startKeyNav(document, document.getElementById("container"));
 			} else {
-				ownEditor.editor(div, entry ? entry : {content: newXml, id: 0}, uneditable);
+				customizeEditor.editor(div, entry ? entry : {content: newXml, id: 0}, uneditable);
 			}
 		};
 		Screenful.Editor.harvester=function(div){
-			if(!ownEditor){
+			if(!usingOwnEditor){
 				return Xonomy.harvest();
 			} else {
-				return ownEditor.harvester(div);
+				return customizeEditor.harvester(div);
 			}
 		};
 		Screenful.Editor.allowSourceCode=true;

--- a/website/widgets/editing-override.js
+++ b/website/widgets/editing-override.js
@@ -40,6 +40,24 @@ var EditingOverride={};
     //div = the div from which you should harvest the contents of the editor
     var headword=$(div).find("input.headword").val();
     return "<entry><headword>"+headword+"</headword></entry>";
+  },
+  adjustDocSpec: function (docSpec) {
+    // NOTE: you normally want to use this method if you don't have a custom editor,
+    // but just want to change certain aspects of how Xonomy presents the document.
+    $.each(docSpec.elements, function (elementName, elementSpec) {
+      // Expand <sense> elements by default.
+      if (elementName === 'sense') {
+        elementSpec.collapsed = function (jsElement) { return false; }
+      }
+      // Make <example> read-only
+      if (elementName === 'example') {
+        elementSpec.isReadOnly = true;
+      }
+      // Hide <partOfSpeech>.
+      if (elementName === 'partOfSpeech') {
+        elementSpec.isInvisible = true;
+      }
+    });
   }
 }`
   );


### PR DESCRIPTION
The Javascript code for your own entry editor can now also be used to customize the docSpec, influencing how Xonomy (or your custom editor) presents the document. This allows you to hide certain elements, make them read-only, expand them by default, etc. To do this, add an adjustDocSpec function that takes the docSpec as a parameter. An example has been added to the included example.