### PR TITLE
Allow user to adjust docSpec.

### DIFF
--- a/website/views/config-editing-override.ejs
+++ b/website/views/config-editing-override.ejs
@@ -36,7 +36,7 @@
 		};
 		Screenful.Editor.allowSourceCode=false;
 		Screenful.Editor.toolbarLinks=[
-			{image: "../../../furniture/cancel.png", caption: "Stop using your own entry editor...", href: "../../../<%=dictID%>/config/editing/"}
+			{image: "../../../furniture/cancel.png", caption: "Disable entry editor customizations...", href: "../../../<%=dictID%>/config/editing/"}
 		];
 		</script>
 		<link type="text/css" rel="stylesheet" href="../../../furniture/ui.css" />

--- a/website/views/config-editing.ejs
+++ b/website/views/config-editing.ejs
@@ -32,7 +32,7 @@
 			Editing.change=Screenful.Editor.changed;
 			if(!entry.content.xonomyMode) entry.content.xonomyMode="nerd";
 			Editing.render(div, entry.content);
-			if(entry.content._js) { //the user is switching back from own entry editor
+			if(entry.content._js) { //the user is disabling any entry editor customizations
 				delete entry.content._js;
 				delete entry.content._css;
 				window.setTimeout(Screenful.Editor.changed, 100);
@@ -52,7 +52,7 @@
 			return JSON.parse(str);
 		};
 		Screenful.Editor.toolbarLinks=[
-			{image: "../../../furniture/cog.png", caption: "Use your own entry editor...", href: "../../../<%=dictID%>/config/editing-override/"}
+			{image: "../../../furniture/cog.png", caption: "Customize entry editor...", href: "../../../<%=dictID%>/config/editing-override/"}
 		];
 		</script>
 		<link type="text/css" rel="stylesheet" href="../../../furniture/ui.css" />

--- a/website/views/entryeditor.ejs
+++ b/website/views/entryeditor.ejs
@@ -116,7 +116,7 @@
 			}
 
 			if(!usingOwnEditor){
-				if(customizeEditor.adjustDocSpec)
+				if(customizeEditor && customizeEditor.adjustDocSpec)
 					customizeEditor.adjustDocSpec(docSpec);
 				Xonomy.render((entry ? entry.content : newXml), div, docSpec);
 				if(!Xonomy.keyNav) Xonomy.startKeyNav(document, document.getElementById("container"));

--- a/website/views/entryeditor.ejs
+++ b/website/views/entryeditor.ejs
@@ -28,9 +28,15 @@
 			<%-editing._css%>
 		</style>
 		<%if(editing._js){%>
-			<script type="text/javascript">var ownEditor=<%-editing._js%>;</script>
+			<script type="text/javascript">
+				var customizeEditor=<%-editing._js%>;
+				var usingOwnEditor=customizeEditor.editor && customizeEditor.harvester;
+			</script>
 		<%} else {%>
-			<script type="text/javascript">var ownEditor=null;</script>
+			<script type="text/javascript">
+				var customizeEditor=null;
+				var usingOwnEditor=false;
+			</script>
 		<%}%>
 		<script type="text/javascript">
 		Screenful.Editor.createUrl="../../../<%=dictID%>/entrycreate.json";
@@ -108,18 +114,21 @@
 					}
 				}
 			}
-			if(!ownEditor){
+
+			if(!usingOwnEditor){
+				if(customizeEditor.adjustDocSpec)
+					customizeEditor.adjustDocSpec(docSpec);
 				Xonomy.render((entry ? entry.content : newXml), div, docSpec);
 				if(!Xonomy.keyNav) Xonomy.startKeyNav(document, document.getElementById("container"));
 			} else {
-				ownEditor.editor(div, entry ? entry : {content: newXml, id: 0}, uneditable);
+				customizeEditor.editor(div, entry ? entry : {content: newXml, id: 0}, uneditable);
 			}
 		};
 		Screenful.Editor.harvester=function(div){
-			if(!ownEditor){
+			if(!usingOwnEditor){
 				return Xonomy.harvest();
 			} else {
-				return ownEditor.harvester(div);
+				return customizeEditor.harvester(div);
 			}
 		};
 		Screenful.Editor.allowSourceCode=true;

--- a/website/widgets/editing-override.js
+++ b/website/widgets/editing-override.js
@@ -40,6 +40,24 @@ var EditingOverride={};
     //div = the div from which you should harvest the contents of the editor
     var headword=$(div).find("input.headword").val();
     return "<entry><headword>"+headword+"</headword></entry>";
+  },
+  adjustDocSpec: function (docSpec) {
+    // NOTE: you normally want to use this method if you don't have a custom editor,
+    // but just want to change certain aspects of how Xonomy presents the document.
+    $.each(docSpec.elements, function (elementName, elementSpec) {
+      // Expand <sense> elements by default.
+      if (elementName === 'sense') {
+        elementSpec.collapsed = function (jsElement) { return false; }
+      }
+      // Make <example> read-only
+      if (elementName === 'example') {
+        elementSpec.isReadOnly = true;
+      }
+      // Hide <partOfSpeech>.
+      if (elementName === 'partOfSpeech') {
+        elementSpec.isInvisible = true;
+      }
+    });
   }
 }`
   );


### PR DESCRIPTION
The Javascript code for your own entry editor can now also be used to customize the docSpec, influencing how Xonomy (or your custom editor) presents the document. This allows you to hide certain elements, make them read-only, expand them by default, etc. To do this, add an adjustDocSpec function that takes the docSpec as a parameter. An example has been added to the included example.