### PR TITLE
Warn if headword exists

### DIFF
--- a/website/lexonomy.js
+++ b/website/lexonomy.js
@@ -643,7 +643,7 @@ app.post(siteconfig.rootPath + ":dictID/entrycreate.json", function (req, res) {
       res.json({ success: false });
     } else {
       ops.readDictConfigs(db, req.params.dictID, function (configs) {
-        ops.createEntry(db, req.params.dictID, null, req.body.content, user.email, {}, async function (entryID, adjustedXml) {
+        ops.createEntry(db, req.params.dictID, null, req.body.content, user.email, {}, async function (entryID, adjustedXml, feedback) {
           db.close();
           var html = "";
           if (configs.xemplate._xsl) {
@@ -654,7 +654,11 @@ app.post(siteconfig.rootPath + ":dictID/entrycreate.json", function (req, res) {
             var doc = (new xmldom.DOMParser()).parseFromString(adjustedXml, "text/xml");
             html = xemplatron.xml2html(doc, configs.xemplate, configs.xema);
           }
-          res.json({ success: true, id: entryID, content: adjustedXml, contentHtml: html });
+          var result = { success: true, id: entryID, content: adjustedXml, contentHtml: html };
+          if (feedback) {
+            result.feedback = feedback;
+          }
+          res.json(result);
         });
       });
     }
@@ -686,7 +690,7 @@ app.post(siteconfig.rootPath + ":dictID/entryupdate.json", function (req, res) {
       res.json({ success: false });
     } else {
       ops.readDictConfigs(db, req.params.dictID, function (configs) {
-        ops.updateEntry(db, req.params.dictID, req.body.id, req.body.content, user.email, {}, async function (adjustedEntryID, adjustedXml, changed) {
+        ops.updateEntry(db, req.params.dictID, req.body.id, req.body.content, user.email, {}, async function (adjustedEntryID, adjustedXml, changed, feedback) {
           db.close();
           var html = "";
           if (configs.xemplate._xsl) {
@@ -697,7 +701,11 @@ app.post(siteconfig.rootPath + ":dictID/entryupdate.json", function (req, res) {
             var doc = (new xmldom.DOMParser()).parseFromString(adjustedXml, "text/xml");
             html = xemplatron.xml2html(doc, configs.xemplate, configs.xema);
           }
-          res.json({ success: true, id: adjustedEntryID, content: adjustedXml, contentHtml: html });
+          var result = { success: true, id: adjustedEntryID, content: adjustedXml, contentHtml: html };
+          if (feedback) {
+            result.feedback = feedback;
+          }
+          res.json(result);
         });
       });
     }

--- a/website/libs/screenful/screenful-editor.js
+++ b/website/libs/screenful/screenful-editor.js
@@ -268,6 +268,22 @@ Screenful.Editor={
       }
     }
   },
+  feedbackMessage: function(feedback) {
+    // Server has some feedback about the operation. For example:
+    // - headword already exists
+    // - another user seems to be editing this entry
+    var info = '';
+    var message = Screenful.Loc[feedback.type]; // e.g. saveFeedbackHeadwordExists
+    if (!message) {
+      message = feedback.type; // no localized message; just show the code
+    }
+    if (message) {
+      message += feedback.info ? feedback.info : "";
+    } else {
+      message = "Server feedback: " + JSON.stringify(feedback);
+    }
+    return message;
+  },
   save: function(event){
     Screenful.Editor.hideHistory();
     var id=Screenful.Editor.entryID;
@@ -295,7 +311,11 @@ Screenful.Editor={
             Screenful.Editor.editor(document.getElementById("editor"), data);
     		  }
           $("#container").hide().fadeIn();
-          Screenful.status(Screenful.Loc.ready);
+          if (data.feedback) {
+            Screenful.status(Screenful.Editor.feedbackMessage(data.feedback));
+          } else {
+            Screenful.status(Screenful.Loc.ready);
+          }
           Screenful.Editor.updateToolbar();
           Screenful.Editor.needsSaving=false;
           if(data.redirUrl) window.location=data.redirUrl;
@@ -330,7 +350,11 @@ Screenful.Editor={
             Screenful.Editor.editor(document.getElementById("editor"), data);
 		      }
           $("#container").hide().fadeIn();
-          Screenful.status(Screenful.Loc.ready);
+          if (data.feedback) {
+            Screenful.status(Screenful.Editor.feedbackMessage(data.feedback));
+          } else {
+            Screenful.status(Screenful.Loc.ready);
+          }
           Screenful.Editor.needsSaving=false;
           Screenful.Editor.updateToolbar();
           if(data.redirUrl) window.location=data.redirUrl;

--- a/website/libs/screenful/screenful-editor.js
+++ b/website/libs/screenful/screenful-editor.js
@@ -312,10 +312,10 @@ Screenful.Editor={
     		  }
           $("#container").hide().fadeIn();
           if (data.feedback) {
-            Screenful.status(Screenful.Editor.feedbackMessage(data.feedback));
-          } else {
-            Screenful.status(Screenful.Loc.ready);
+            Screenful.status(Screenful.Editor.feedbackMessage(data.feedback), "alert");
           }
+          Screenful.status(Screenful.Loc.ready);
+
           Screenful.Editor.updateToolbar();
           Screenful.Editor.needsSaving=false;
           if(data.redirUrl) window.location=data.redirUrl;
@@ -351,10 +351,10 @@ Screenful.Editor={
 		      }
           $("#container").hide().fadeIn();
           if (data.feedback) {
-            Screenful.status(Screenful.Editor.feedbackMessage(data.feedback));
-          } else {
-            Screenful.status(Screenful.Loc.ready);
+            Screenful.status(Screenful.Editor.feedbackMessage(data.feedback), "alert");
           }
+          Screenful.status(Screenful.Loc.ready);
+
           Screenful.Editor.needsSaving=false;
           Screenful.Editor.updateToolbar();
           if(data.redirUrl) window.location=data.redirUrl;

--- a/website/libs/screenful/screenful-loc-cs.js
+++ b/website/libs/screenful/screenful-loc-cs.js
@@ -15,6 +15,7 @@ Screenful.Loc={
   readingFailed: "Neexistuje.",
   saving: "Ukládá se...",
   savingFailed: "Nepovedlo se to uložit.",
+  saveFeedbackHeadwordExists: "WARNING: another entry with this headword exists. ID=",
   deleting: "Maže se...",
   deletingFailed: "Nepovedlo se to smazat.",
   deleteConfirm: "Pozor s tímhle! Opravdu to chceš smazat?",

--- a/website/libs/screenful/screenful-loc-en.js
+++ b/website/libs/screenful/screenful-loc-en.js
@@ -17,6 +17,7 @@ Screenful.Loc={
   readingFailed: "No such item.",
   saving: "Saving...",
   savingFailed: "Failed to save.",
+  saveFeedbackHeadwordExists: "WARNING: another entry with this headword exists. ID=",
   deleting: "Deleting...",
   deletingFailed: "Failed to delete.",
   deleteConfirm: "Careful now! Are you sure?",

--- a/website/libs/screenful/screenful-loc-ga.js
+++ b/website/libs/screenful/screenful-loc-ga.js
@@ -14,6 +14,7 @@ Screenful.Loc={
   readingFailed: "Ní ann don iontráil.",
   saving: "Á shábháil...",
   savingFailed: "Níor éirigh liom na sonraí a shábháil.",
+  saveFeedbackHeadwordExists: "WARNING: another entry with this headword exists. ID=",
   deleting: "Á scrios...",
   deletingFailed: "Níor éirigh liom na sonraí a scrios.",
   deleteConfirm: "Cúramach anois! An bhfuil tú cinnte?",

--- a/website/libs/screenful/screenful.css
+++ b/website/libs/screenful/screenful.css
@@ -20,4 +20,23 @@ body {font-family: sans-serif; background-color: #ffffff; margin: 0; padding: 0;
 #statusbar span.wait { background-image: url(loader.gif); display: inline-block; width: 30px; height: 10px; background-repeat: no-repeat; background-position: left center; margin-right: 1em;}
 #statusbar span.warn { background-image: url(exclamation.png); display: inline-block; width: 16px; height: 10px; background-repeat: no-repeat; background-position: left center; margin-right: 0.75em;}
 
+#statusbar .alertmessage {
+    color: black;
+    background-color: #ffff77;
+    font-weight: bold;
+    padding: 2px;
+    margin-right: 20px;
+    border: 2px solid black;
+    display: none;
+}
+#statusbar .closeIcon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    position: relative;
+    top: 3px;
+    background-image: url(cross.png);
+    cursor: pointer;
+}
+
 .wyc { display: inline-block; background-image: url(loader.gif); background-position: center center; background-repeat: no-repeat; width: 30px; height: 10px; }

--- a/website/libs/screenful/screenful.css
+++ b/website/libs/screenful/screenful.css
@@ -19,24 +19,7 @@ body {font-family: sans-serif; background-color: #ffffff; margin: 0; padding: 0;
 
 #statusbar span.wait { background-image: url(loader.gif); display: inline-block; width: 30px; height: 10px; background-repeat: no-repeat; background-position: left center; margin-right: 1em;}
 #statusbar span.warn { background-image: url(exclamation.png); display: inline-block; width: 16px; height: 10px; background-repeat: no-repeat; background-position: left center; margin-right: 0.75em;}
-
-#statusbar .alertmessage {
-    color: black;
-    background-color: #ffff77;
-    font-weight: bold;
-    padding: 2px;
-    margin-right: 20px;
-    border: 2px solid black;
-    display: none;
-}
-#statusbar .closeIcon {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    position: relative;
-    top: 3px;
-    background-image: url(cross.png);
-    cursor: pointer;
-}
+#statusbar .alertmessage { display: none; color: black; background-color: #ffff77; font-weight: bold; padding: 2px; margin-right: 20px; border: 2px solid black; }
+#statusbar .closeIcon { display: inline-block; width: 16px; height: 16px; position: relative; top: 3px; background-image: url(cross.png); cursor: pointer; }
 
 .wyc { display: inline-block; background-image: url(loader.gif); background-position: center center; background-repeat: no-repeat; width: 30px; height: 10px; }

--- a/website/libs/screenful/screenful.js
+++ b/website/libs/screenful/screenful.js
@@ -17,7 +17,6 @@ var Screenful={
     $("#envelope").css("bottom", (footerHeight+statusbarHeight+2)+"px");
   },
   status: function(str, style){
-    console.log("STATUS: " + str);
     if(window.parent!=window && window.parent.Screenful) window.parent.Screenful.status(str, style);
     else {
       if(style==="alert") {

--- a/website/libs/screenful/screenful.js
+++ b/website/libs/screenful/screenful.js
@@ -1,8 +1,9 @@
 var Screenful={
   createEnvelope: function(scrollable){
     var html="<div id='envelope' class='"+(scrollable?"scrollable":"")+"'></div>";
-    if(window.parent==window || (window.parent!=window && !window.parent.Screenful)) html+="<div id='statusbar'><span class='statusmessage'></span></div>";
+    if(window.parent==window || (window.parent!=window && !window.parent.Screenful)) html+="<div id='statusbar'><span class='alertmessage'><span class='text'>(ALERT)</span> <span class='closeIcon'></span></span><span class='statusmessage'></span></div>";
     if($("#footer").length>0) $("#footer").before(html); else $("body").append(html);
+    $("#statusbar .alertmessage .closeIcon").on("click", function () { $("#statusbar .alertmessage").hide(); });
     Screenful.resize();
     $(window).on("resize", Screenful.resize);
     $("body").append("<div id='curtain' style='display: none'></div>")
@@ -19,9 +20,14 @@ var Screenful={
     console.log("STATUS: " + str);
     if(window.parent!=window && window.parent.Screenful) window.parent.Screenful.status(str, style);
     else {
-      if(style=="wait") str="<span class='wait'></span>"+str;
-      if(style=="warn") str="<span class='warn'></span>"+str;
-      $("#statusbar .statusmessage").html(str);
+      if(style==="alert") {
+        $("#statusbar .alertmessage .text").html(str);
+        $("#statusbar .alertmessage").show();
+      } else {
+        if(style=="wait") str="<span class='wait'></span>"+str;
+        if(style=="warn") str="<span class='warn'></span>"+str;
+        $("#statusbar .statusmessage").html(str);
+      }
     }
   },
 

--- a/website/libs/screenful/screenful.js
+++ b/website/libs/screenful/screenful.js
@@ -16,6 +16,7 @@ var Screenful={
     $("#envelope").css("bottom", (footerHeight+statusbarHeight+2)+"px");
   },
   status: function(str, style){
+    console.log("STATUS: " + str);
     if(window.parent!=window && window.parent.Screenful) window.parent.Screenful.status(str, style);
     else {
       if(style=="wait") str="<span class='wait'></span>"+str;


### PR DESCRIPTION
The headword (actually the "title") of an entry is compared to the existing entries in the database when creating or updating an entry. If another entry with the same title exists, a prominent alert is shown in the status bar that doesn't disappear unless dismissed by the user.

Possibly still to do:
- see if the way this server alert is returned to the client and presented to the user is reusable for similar situations (e.g. timestamp check failed)
- translate feedback message saveFeedbackHeadwordExists
- (possibly) hide the alert automatically after some time?
- make it configurable whether or not we want to see this type of message?