### PR TITLE
Minor enhancements

### DIFF
--- a/website/adminscripts/add.py
+++ b/website/adminscripts/add.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys, os, os.path
 

--- a/website/adminscripts/changePassword.py
+++ b/website/adminscripts/changePassword.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 import sys

--- a/website/adminscripts/export.py
+++ b/website/adminscripts/export.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os.path
 import sqlite3

--- a/website/adminscripts/import.py
+++ b/website/adminscripts/import.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import os.path

--- a/website/adminscripts/init.py
+++ b/website/adminscripts/init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Script to initialize database and users, from the siteconfig.json file
 

--- a/website/adminscripts/updates.py
+++ b/website/adminscripts/updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Script to upgrade the schema of Lexonomy's main database.
 

--- a/website/widgets/xema-designer.js
+++ b/website/widgets/xema-designer.js
@@ -2,7 +2,7 @@ var XemaDesigner={};
 XemaDesigner.onchange=function(){};
 XemaDesigner.isValidXmlName=function(str){
 	if(str=="") return false;
-	if(/[:=\s\"\']/.test(str)) return false;
+	if(/[=\s\"\']/.test(str)) return false;
 	try{ $.parseXML("<"+str+"/>"); } catch(err){ return false; }
 	return true;
 };


### PR DESCRIPTION
1. Allow colon ':' character in XML attribute names. Example of how I use this:

 `<target xml:lang='en'>The dog is thin.</target>`

See W3C standard for [namespace declaration](https://www.w3.org/TR/1999/REC-xml-names-19990114/#ns-decl)

2. Make shebang in Python scripts more portable. In particular for MacOS, the location of Python can vary depending on how it is installed. Instead of

#!/usr/bin/python3

I changed all the scripts in "website/adminscripts" to start with:

#!/usr/bin/env python3

See this [SO discussion](https://stackoverflow.com/questions/17846908/proper-shebang-for-python-script/17846946) of this topic.
