### PR TITLE
Fix a file name: init.js -> init.py

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Make sure that your docker-compose points to the right volume locations on the h
 
 Initialize database and admin user:
 ```
-docker-compose exec python3 adminscripts/init.js
+docker-compose exec python3 adminscripts/init.py
 ```
 This will create a database file inside your data volume.
 


### PR DESCRIPTION
There is no file named "init.js" in the adminscripts directory, only init.py and it is run by python3 according to the guide:
docker-compose exec python3 adminscripts/init.js
So I assume it should be:
docker-compose exec python3 adminscripts/init.py
