### PR TITLE
Filter on flag

### DIFF
--- a/website/js/store.js
+++ b/website/js/store.js
@@ -61,9 +61,11 @@ class StoreClass {
       } else {
          let searchtext = searchParams.searchtext || ""
          let modifier = searchParams.modifier || "start"
-         if(searchtext !== this.data.searchtext || modifier !== this.data.modifier){
+         let searchflag = searchParams.searchflag || ""
+         if(searchtext !== this.data.searchtext || modifier !== this.data.modifier || searchflag !== this.data.searchflag){
             this.data.searchtext = searchtext
             this.data.modifier = modifier
+            this.data.searchflag = searchflag
             this.loadEntryList()
          }
       }
@@ -84,7 +86,8 @@ class StoreClass {
       this.loadEntryList()
       url.setQuery(this.data.searchtext ? {
          s: this.data.searchtext,
-         m: this.data.modifier
+         m: this.data.modifier,
+         f: this.data.searchflag
       } : {}, true)
    }
 
@@ -159,6 +162,7 @@ class StoreClass {
          dictId: null,
          entryId: null,
          searchtext: '',
+         searchflag: '',
          modifier: 'start',
          mode: 'view',
          userAccess: {
@@ -286,6 +290,7 @@ class StoreClass {
       let data = {
          searchtext: this.data.searchtext,
          modifier: this.data.modifier,
+         searchflag: this.data.searchflag,
          howmany: howmany ? howmany : (this.data.dictConfigs.titling.numberEntries || 1000)
       }
       if(authorized){

--- a/website/lexonomy.py
+++ b/website/lexonomy.py
@@ -236,7 +236,7 @@ def entryflag(dictID: str, user: User, dictDB: Connection, configs: Configs):
 @authDict(["canEdit"])
 def subget(dictID: str, user: User, dictDB: Connection, configs: Configs):
     """For use with searching for eligible subentries: given a doctype and a lemma, find matching entries. (it is implied the doctype allows the entry to become a subentry)"""
-    total, entryIds = ops.searchEntries(dictDB, configs, request.query.doctype, request.query.lemma, "wordstart", limit = 100)
+    total, entryIds = ops.searchEntries(dictDB, configs, request.query.doctype, None, request.query.lemma, "wordstart", limit = 100)
     entries = ops.readEntries(dictDB, configs, entryIds, xml = False)
     return {"success": True, "total": total, "entries": entries}
 
@@ -739,7 +739,7 @@ def entrylist(dictID: str, doctype: str, user: User, dictDB: Connection, configs
             return {"success": True, "entries": entries}
     else:
         howmany = int(request.forms.howmany) if request.forms.howmany else 100
-        total, entryIds = ops.searchEntries(dictDB, configs, doctype, request.forms.searchtext, request.forms.modifier, request.forms.sortdesc, limit = howmany)
+        total, entryIds = ops.searchEntries(dictDB, configs, doctype, request.forms.searchflag, request.forms.searchtext, request.forms.modifier, request.forms.sortdesc, limit = howmany)
         entries = ops.readEntries(dictDB, configs, entryIds, xml=False, sortdesc=request.forms.sortdesc)
         return {"success": True, "entries": entries, "total": total}
 
@@ -753,9 +753,10 @@ def publicsearch(dictID: str):
     modifier = request.forms.modifier or "start"
     howmany = request.forms.howmany or 100
     searchtext = request.forms.searchtext
+    searchflag = request.forms.searchflag
     doctype = configs['xema']['root']
 
-    total, entryIds = ops.searchEntries(dictDB, configs, doctype, searchtext, modifier, False, limit = howmany)
+    total, entryIds = ops.searchEntries(dictDB, configs, doctype, searchflag, searchtext, modifier, False, limit = howmany)
     return {"success": True, "entries": ops.readEntries(dictDB, configs, entryIds, titlePlain=True), "total": total}
 
 

--- a/website/riot/dict-config-flagging.riot
+++ b/website/riot/dict-config-flagging.riot
@@ -2,8 +2,7 @@
    <loading-overlay if={state.isLoading || state.isSaving}/>
    <dict-nav links={[["config", "Configure"], ["flagging", "Entry flags"]]}/>
    <h1>Entry flags</h1>
-   <dict-config-buttons save-data={saveData}
-         show-save={state.data.flags.length}></dict-config-buttons>
+   <dict-config-buttons save-data={saveData}></dict-config-buttons>
    <template if={!state.isLoading}>
       <div if={!state.data.flags.length}
             class="center-align grey-text">

--- a/website/riot/dict-entry-filter.riot
+++ b/website/riot/dict-entry-filter.riot
@@ -16,6 +16,13 @@
          <option value="wordstart" selected={dictData.modifier == 'wordstart'}>contains a word that starts like this</option>
          <option value="substring" selected={dictData.modifier == 'substring'}>contains this sequence of characters</option>
       </select>
+      <select id="flagType" if="{store.data && store.data.config && store.data.config.flagging.flags.length}">
+         <option selected={!dictData.searchflag} value="">Any flag</option>
+         <option each={flag in store.data.config.flagging.flags} 
+            selected={dictData.searchflag === flag.name}
+            value="{flag.name}"
+         ><span><span class="flag-dot" style="background: {flag.color};"></span> {flag.label}</span></option>
+      </select>
    </div>
 
    <style>
@@ -42,6 +49,15 @@
          right: 5px;
          top: 11px;
       }
+      .flag-dot {
+         width: 1em;
+         height: 1em;
+         content: " ";
+         display: inline-block;
+         border-radius: 100%;
+         vertical-align: middle;
+         margin-right: 0.5em;
+      }
    </style>
 
    <script>
@@ -49,6 +65,7 @@
          search() {
             this.dictData.searchtext = $('#searchBox').val()
             this.dictData.modifier = $('#searchType').val()
+            this.dictData.searchflag = $('#flagType').val()
             this.props.searchFunc()
          },
 

--- a/website/riot/main.riot
+++ b/website/riot/main.riot
@@ -112,7 +112,8 @@
                let query = route.query()
                this.store.changeSearchParams({
                   searchtext: decodeURIComponent(query.s || ""),
-                  modifier: query.m
+                  modifier: query.m,
+                  searchflag: decodeURIComponent(query.f || ""),
                })
 
                this.update(Object.assign({


### PR DESCRIPTION
Added a dropdown to filter the entry list based on flags.
User needs to hit `enter` in the search field before the search is executed.

This feature is something that came up during a discussion about one of our own dictionaries.
Since flags are now stored in the database, this performs reasonably well now.

![image](https://user-images.githubusercontent.com/15146423/179745636-2b0609e0-ea9e-402c-8c8d-a5872c12f7b1.png)
